### PR TITLE
Add maintainer documentation

### DIFF
--- a/maintaining-a-track/README.md
+++ b/maintaining-a-track/README.md
@@ -1,0 +1,90 @@
+# Maintaining an Exercism Language Track
+
+* [Philosophy](#philosophy)
+
+  * [Be Kind](#be-kind)
+  * [Be Responsive](#be-responsive)
+  * [Empower New Contributors](#empower-new-contributors)
+  * [Recognize Contributions](#recognize-contributions)
+  * [Praise in Public, Reprimand in Private](#praise-in-public-reprimand-in-private)
+  * [Improve the Learning Experience](#improve-the-learning-experience)
+  * [Collaborate](#collaborate)
+
+* [Day-to-Day Tactics](#day-to-day-tactics)
+
+  * [Watch Key Repositories](#watch-key-repositories)
+  * [Perform Common Tasks](#perform-common-tasks)
+
+## Philosophy
+
+### Be Kind
+
+First and foremost, strive always to be kind, humble and show gratitude for the work being contributed.
+
+**_Kind_ is not the same thing as _nice_.** Being kind does not mean being a pushover.
+Doing the right thing is not always the thing that pleases the most people.
+
+### Be Responsive
+
+Even if you do not have an answer immediately, respond quickly. This lets the person on the other end know that they've been heard. If it takes a long time to figure out what to do, be honest about what's going on.
+
+When responding to someone, `@`-mention them. This will ensure that they'll get a notification, even if they're not watching the issue or pull request.
+
+### Empower New Contributors
+
+As a maintainer, your most important task is to make it as easy as possible for people to successfully contribute. The exact details will vary, but often this means things like:
+
+- documenting or scripting the necessary steps to get started with the codebase
+- helping people understand how to use the tools successfully (including git and GitHub)
+- writing detailed issues about work that needs to be done so that someone without knowledge of the project can easily find something to work on
+- improving the tooling to reduce friction
+- answering questions
+- reviewing pull requests
+
+### Recognize Contributions
+
+Don't just merge a PR—thank contributors for their contributions.
+
+Any contribution that helps is great, it doesn't have to be a great contribution. Let contributors know that you really value their work, no matter how small the contribution is.
+
+If someone does great work consistently over time, invite them to become maintainers.
+
+### Praise in Public, Reprimand in Private
+
+If there is a contributor or commenter that is not behaving as we would like then it should be handled outside of GitHub if possible.
+
+### Improve the Learning Experience
+
+The exercises often start out as an experiment. As people do the exercises we learn a lot about what's interesting, tough, boring, challenging, fun, tricky, confusing, or useful.
+
+Over time we try to:
+
+- improve the problem descriptions in [exercism/x-common](github.com/exercism/x-common)
+- add missing edge cases in the test suites
+- reorder tests to allow a more incremental approach to solving the problem
+- improve the test suites to avoid pushing people towards specific solutions
+- reorder exercises to provide a gentler learning curve on the site
+- deprecate exercises that don't provide enough value
+
+### Collaborate
+
+Maintaining a track is so much more fun and interesting when there are several people actively involved in the process.
+
+Even with full push access, **create pull requests**. This notifies the other maintainers about the change.
+As a general rule, ensure a fellow maintainer reviews your pull request, unless it is utterly trivial.
+
+## Day-to-Day Tactics
+
+### Watch Key Repositories
+
+This will notify you of all new issues, pull requests, and comments.
+
+In addition to the language track repository itself, you may also want to watch:
+
+- the [exercism/x-common](http://github.com/exercism/x-common) repository which contains all of the exercise descriptions and metadata. Many discussions about improvements to the exercises happen here.
+- the [exercism/discussions](http://github.com/exercism/discussions) repository where a lot of high-level discussions about Exercism itself happen (roadmap, direction, ideas, conundrums).
+
+### Perform Common Tasks
+
+- [Triage issues](/maintaining-a-track/triaging-issues.md)
+- [Review pull requests](/maintaining-a-track/reviewing-a-pull-request.md)

--- a/maintaining-a-track/inviting-new-maintainers.md
+++ b/maintaining-a-track/inviting-new-maintainers.md
@@ -1,0 +1,11 @@
+The maintainers of a track should feel free to extend invitations to contributors asking them to join the team.
+
+You may invite new maintainers using whatever medium feels most appropriate, including but not limited to email or Gitter.
+
+In general, we would like to keep these invitations short, to make it clear that we are not asking for a huge and/or overwhelming commitment.
+
+General topics that we feel are good to touch on in the invitation:
+
+* **Thank you** for your past contributions. Be specific on points that we like, for positive reinforcement.
+* https://github.com/exercism/exercism.io/blob/master/docs/maintaining-a-track.md
+* **No pressure** regarding how much to commit to (you can commit to as much or as little as you like!), or even to say yes at all! Either way, you are still welcome to contribute as you already have been!

--- a/maintaining-a-track/reviewing-a-pull-request.md
+++ b/maintaining-a-track/reviewing-a-pull-request.md
@@ -1,0 +1,85 @@
+# Reviewing a Pull Request
+
+This guide is about reviewing pull requests on Exercism language tracks.
+
+## Philosophy
+
+* **Respond Kindly** We want every contributor to be glad they are here, even if we don't ultimately merge their pull request.
+* **Respond Quickly** Promptness encourages frequent, high-quality contributions from community members and other maintainers.
+* **Resolve Quickly** A pull request should either be actively in-progress, or it should be merged or closed.
+
+Closing pull requests kindly is not easy. Two great articles about this are:
+
+* [Kindly Closing Pull Requests](https://github.com/blog/2124-kindly-closing-pull-requests) by Mike McQuaid
+* [The Art of Closing](https://blog.jessfraz.com/post/the-art-of-closing/) by Jessie Frazelle
+
+## Reviewing an Exercism Exercise
+
+When reviewing a pull request, always remember the past. That is, remember that numerous users have already submitted an exercise and any significant change to an exercise invalidates their submissions to some extent.
+
+That said, we should not be afraid to change things for the better.
+
+If the tests do change significantly enough to break existing solutions, it's worth calling it out so that we can discuss whether or not the change is worth it in this particular case.
+
+### Consider the Structural Requirements
+
+We have a tool, [`configlet`](https://github.com/exercism/configlet#configlet), which does track-level linting. This runs on Travis CI when a pull request is submitted.
+
+The tool checks the following (so you don't have to):
+
+- Is the `config.json` file syntactically correct?
+- Does the `config.json` list the correct exercises?
+    - Has every exercise listed been implemented?
+    - Has every implemented exercise been added to the config?
+    - Have any exercises been implemented that shouldn't have been? E.g. exercises that are inappropriate or uninteresting in the language.
+- Is the example solution named with `/example/i` in the path? If not that file will be served when people fetch the exercise.
+
+You can also [download it](https://github.com/exercism/configlet/releases/latest) and run it locally.
+
+Things that the tool does not yet do, and which should be checked:
+
+- Is the test file named correctly, per the guidelines in the language track? (TODO: add to `configlet`)
+- Does the directory name of the exercise match that of [an existing, known exercism exercise slug](https://github.com/exercism/x-common/tree/master/exercises)?
+
+If there is no automated checking, then you should also verify:
+
+- Do the tests pass against the example solution?
+
+### Consider Future Maintainers
+
+- Does the commit message contain the [exercise slug](https://github.com/exercism/x-common/blob/master/CONTRIBUTING.md#updating-a-generic-problem-description)?
+- Does the commit message explain _why_ the change was made?
+
+### Consider the User Experience
+
+- Is the exercise listed too early in the list? Too late?
+- Is the exercise too similar to the ones just before or after it?
+- Are the tests forcing people towards a particular implementation?
+- Are the tests ordered so that they encourage incremental changes?
+- Do the test names help the user understand the _why_ of the requirement?
+- Will the test failures make sense to the person trying to solve the problem?
+- Does the exercise pull in unnecessary dependencies?
+- Have all but the first test been skipped? (Only for tracks that use `pending` or `skip` or `ignore` directives)
+- If the exercise introduced difficult language features, is there a `HINTS.md` file that points to some good documentation about it?
+- Do the tests use the data from the [`canonical-data.json`](https://github.com/exercism/x-common#test-data-format-canonical-datajson) file (if it exists)? Are any of the deviations from `canonical-data.json` generally useful to other language tracks? _If so, consider submitting them back to the x-common repository._
+
+There is usually no right answer, and sometimes the best answer is "I don't know, we'll see."
+If it seems good enough we can merge it. It can always be improved later.
+
+### Encourage Best Practices
+
+Consider the tests carefully. They are the public-facing product. These should follow language-idioms and make good use of the standard library.
+
+When reviewing pull requests, try to coach the contributor towards a better solution. Try not to prescribe changes outright. Ask questions, be curious, and remember that their perspective might be just as valid as yours.
+
+Exercism should generally adhere to the idioms of a language. However, that should not stand in the way of implementing a great exercise.
+
+The example solution is not public-facing, and as long as it passes the tests, we can let it in.
+
+## Reviewing Changes to Track Tooling
+
+Changes to tooling are not user-facing, but anything that is weird or complicated will make it harder to contribute to the track.
+
+---------
+
+Inspired by the ["reviewing a pull request"](https://github.com/jekyll/jekyll/blob/master/docs/_docs/maintaining/reviewing-a-pull-request.md) documentation in the Jekyll project.

--- a/maintaining-a-track/triaging-issues.md
+++ b/maintaining-a-track/triaging-issues.md
@@ -1,0 +1,33 @@
+# Triaging Issues in an Exercism Language Track
+
+Issues need to be unambiguous and actionable. If it's hard to figure out what
+an issue is about, or what needs to be done, then the issue probably won't get
+fixed.
+
+## Making Issues Great
+
+The goal of triaging issues is to make sure that each issue is actionable.
+
+A great issue also has enough context that it could be tackled by someone who has never contributed
+to Exercism before.
+
+When reading an issue you should be able to answer questions like...
+
+* What is the problem?
+* Why is this a problem?
+* Who might run into it? Everyone? Or is it an edge case?
+* What needs to be done? How will we know that the issue can be closed?
+  Is there something we need to figure out or decide before it can be fixed?
+* Where in the code will the fix go? This might be obvious, but it might not be. If we can point
+  to the right directory or file, that helps.
+
+If the issue isn't great yet, then the best help you can provide is to ask clarifying questions to help
+make it great.
+
+## Still Relevant?
+
+Along the way you might run into issues that have already been resolved (we just forgot to close it), or
+that just aren't relevant any more, because the world has moved on.
+
+If you see one of these, then add a comment suggesting that we close it, with a note about why it can be
+closed.

--- a/maintaining-a-track/writing-documentation.md
+++ b/maintaining-a-track/writing-documentation.md
@@ -1,0 +1,58 @@
+# Writing Language Track Documentation
+
+If someone is going to use Exercism to ramp up in a new programming language, they are going to need to get their local environment set up so that they can solve the problems in that language.
+
+At the very minimum, people will need to know:
+
+0. how to install the programming language on their machine
+0. how to install any necessary dependencies
+0. how to run the tests
+
+We also like to add some other goodies, for example:
+
+* **a short introduction about the language**. This helps entice people to start learning it. This should not go into too much detail, as it can link to more in-depth information. It should give a high-level idea of what kind of language it is, and what type of problems it's used to solve, or where it is typically used. The keyword here is *enticing*. We don't need to tell people everything, just get them curious enough to want to try it, or to read more about it.
+* **where to learn the basics**. If you're learning the language from scratch, what are some good resources that teach you about the language. Tutorials, websites, books, videos—we're looking for things that people would use to orient themselves and get a good introduction. This is often what you'd use *before* doing Exercism.
+* **references and resources**. As people work the exercises on Exercism, they'll probably want reference materials. Where can they find the documentation for the standard library? Are there any useful tools, such as linters or style guides? Are there forums or channels where people can meet other people and ask for help?
+
+This documentation gets included on the website on the page for each language track. You can browse the track documentation starting from [the main language page](http://exercism.io/languages).
+
+## File Structure
+
+Everything that is specific to a particular programming language lives in the repository for that particular language track, making it easy for the people who maintain the track to manage it.
+
+Since all the language track documentation gets included on the site, it needs to be standardized. We've settled on the following file structure:
+
+```bash
+.
+└── docs/
+    ├── img/
+    │   ├── image-one.svg
+    │   ├── image-two.png
+    │   └── image-three.jpg
+    ├── ABOUT.md
+    ├── INSTALLATION.md
+    ├── LEARNING.md
+    ├── RESOURCES.md
+    └── TESTS.md
+```
+
+The mapping of topics to filenames goes like this:
+
+* `INSTALLATION.md` - how to install the language and any dependencies
+* `TESTS.md` - how to run the tests
+* `ABOUT.md` - short, enticing introduction to the language
+* `LEARNING.md` - where to get an introduction to the language if you're learning it for the first time
+* `RESOURCES.md` - references, tools, etc.
+
+Any images referenced in the markdown files need to live within the `docs/img` directory. If the directory doesn't exist, you can create it when you need it.
+
+Use the relative path to this directory when referring to the images in the markdown. E.g., if you have an image named `docs/img/dropdown.png`, then you would reference it with:
+
+```
+![](/docs/img/dropdown.png)
+```
+
+There are a number of variations on markdown image syntax. [This guide](https://daringfireball.net/projects/markdown/syntax#img) has more details.
+
+This will show up correctly when you browse the documentation within the repository on GitHub, and also when it is included on the Exercism website, where we rewrite the paths to refer to the correct API endpoint that serves the images.
+


### PR DESCRIPTION
This is a direct copy/paste of the existing maintainer documentation from exercism/exercism.io/docs. See https://github.com/exercism/docs/issues/2

[View the `maintaining-a-track` directory](https://github.com/exercism/docs/tree/maintainer-docs/maintaining-a-track/)