### PR TITLE
Add a roadmap

### DIFF
--- a/roadmap.md
+++ b/roadmap.md
@@ -1,0 +1,28 @@
+# Roadmap
+
+[design-of-exercism]: http://tinyletter.com/exercism/letters/the-delightful-design-of-exercism
+
+Exercism can be seen as two quite distinct projects:
+
+1. The Product
+2. The Curriculum
+
+## The Product
+
+We are currently investing efforts in a complete reboot of the Exercism website. The original site was never designed, it just kind of happened, organically over time. We are now going back to basics, working with design professionals to ask the fundamental questions that will inform the user experience.
+
+The core idea of Exercism is a good one, and there are some things that work extremely well. Most of the user experience, however, is not as delightful as it could be.
+
+Once we have explored the key questions, we will progress to exploring wireframes and user flows, and then eventually visual design and writing copy. At the very end of this, we will implement the new website completely from scratch, focusing on clean, simple, idiomatic code, and good performance.
+
+We will release the new website under the same license as the existing one.
+
+In the meanwhile, we welcome tweaks and experiments to the existing website.
+
+You can read more about this in the article [The Delightful Design of Exercism][design-of-exercism].
+
+## The Curriculum
+
+For the curriculum, the focus is on _sustainability_. We need to have enough people maintaining and contributing to each language track that no single person gets overwhelmed or burned out. In order to achieve this, we will be working to make it easier to get started contributing to a language track, as well as figuring out how to reach and entice more potential contributors.
+
+At the level of each individual track, we're working on improving the experience for people working through the solutions. Each exercise should be compelling, it should inspire useful, interesting conversations, and the difficulty of exercises throughout the track should gradually increase.


### PR DESCRIPTION
This is a complete rewrite, since a lot has happened since the [previous version of
a roadmap](https://github.com/exercism/exercism.io/blob/master/docs/roadmap.md) was added to the exercism/exercism.io repo. See #2 


[View rendered roadmap](https://github.com/exercism/docs/blob/roadmap/roadmap.md)