### PR TITLE
Clarify image paths for track documentation

### DIFF
--- a/maintaining-a-track/writing-documentation.md
+++ b/maintaining-a-track/writing-documentation.md
@@ -46,7 +46,8 @@ The mapping of topics to filenames goes like this:
 
 Any images referenced in the markdown files need to live within the `docs/img` directory. If the directory doesn't exist, you can create it when you need it.
 
-Use the relative path to this directory when referring to the images in the markdown. E.g., if you have an image named `docs/img/dropdown.png`, then you would reference it with:
+When referring to the images in the markdown, use a path starting with `/docs` (note the slash)
+E.g., if you have an image named `docs/img/dropdown.png`, then you would reference it with:
 
 ```
 ![](/docs/img/dropdown.png)


### PR DESCRIPTION
We need the path to start with a slash, and be the full path from the
root of the repository.

This is an absolute path, if you consider the repository root.

I'm still not sure I am explaining this clearly.

Thanks @joelwallis for catching this. :sparkles: 