### PR TITLE
glossary terms in alphabetical order

### DIFF
--- a/glossary.md
+++ b/glossary.md
@@ -3,14 +3,14 @@
 There are a number of terms that we use that have specific meaning within the
 context of Exercism.
 
+- **exercise** - a language-specific implementation of a specification. Typically consists of a test suite and a README
+- **iteration** - the code that someone writes to make a test suite pass
 - **language** - the name of a programming language, for example _C++_ or _Haskell_
+- **problem** - abstract concept for a programming task on exercism.io
+- **slug** - a short, unique identifier for a problem, specification, or exercise (e.g. `hamming`). Matches `/^[a-z-]+$/`
+- **solution** - a collection of iterations that a single person has done to solve an exercise
+- **specification** - a language-agnostic description of a problem. These live in [the x-common repository][x-common-repo]
 - **track** - a collection of exercises implemented in a given programming language
 - **track id** - a short, unique identifier for a track (e.g. `cpp` or `haskell`). Matches `/^[a-z-]+$/`
-- **problem** - abstract concept for a programming task on exercism.io
-- **specification** - a language-agnostic description of a problem. These live in [the x-common repository][x-common-repo]
-- **exercise** - a language-specific implementation of a specification. Typically consists of a test suite and a README
-- **slug** - a short, unique identifier for a problem, specification, or exercise (e.g. `hamming`). Matches `/^[a-z-]+$/`
-- **iteration** - the code that someone writes to make a test suite pass
-- **solution** - a collection of iterations that a single person has done to solve an exercise
 
 [x-common-repo]: https://github.com/exercism/x-common


### PR DESCRIPTION
I was reading this, and it was not intuitive (to me) as things were ordered, as I expect a glossary to be in alphabetical order.