### PR TITLE
Update slug and track id regexes

### DIFF
--- a/glossary.md
+++ b/glossary.md
@@ -3,16 +3,16 @@
 There are a number of terms that we use that have specific meaning within the
 context of Exercism.
 
-| Term              | Explanation                                                                                                              |
-|-------------------|--------------------------------------------------------------------------------------------------------------------------|
-| **exercise**      | a language-specific implementation of a **specification**. Typically consists of a test suite and a README               |
-| **iteration**     | the code that someone writes to make a test suite pass                                                                   |
-| **language**      | the name of a programming language, for example _C++_ or _Haskell_                                                       |
-| **problem**       | abstract concept for a programming task on exercism.io                                                                   |
-| **slug**          | a short, unique identifier for a **problem**, **specification**, or **exercise** (e.g. `hamming`). Matches `/^[a-z]+(-[a-z]+)*$/` |
-| **solution**      | a collection of **iterations** that a single person has done to solve an **exercise**                                    |
-| **specification** | a language-agnostic description of a **problem**. These live in [the x-common repository][x-common-repo]                 |
-| **track**         | a collection of **exercises** implemented in a given **language**                                                        |
-| **track id**      | a short, unique identifier for a track (e.g. `cpp` or `haskell`). Matches `/^[a-z]+(-[a-z]+)*$/`                                  |
+| Term              | Explanation                                                                                                                                         |
+|-------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| **exercise**      | a language-specific implementation of a **specification**. Typically consists of a test suite and a README                                          |
+| **iteration**     | the code that someone writes to make a test suite pass                                                                                              |
+| **language**      | the name of a programming language, for example _C++_ or _Haskell_                                                                                  |
+| **problem**       | abstract concept for a programming task on exercism.io                                                                                              |
+| **slug**          | a short, unique identifier for a **problem**, **specification**, or **exercise** (e.g. `hamming`). Consists of lowercase words separated by hyphens |
+| **solution**      | a collection of **iterations** that a single person has done to solve an **exercise**                                                               |
+| **specification** | a language-agnostic description of a **problem**. These live in [the x-common repository][x-common-repo]                                            |
+| **track**         | a collection of **exercises** implemented in a given **language**                                                                                   |
+| **track id**      | a short, unique identifier for a track (e.g. `cpp` or `haskell`). Consists of lowercase words separated by hyphens                                  |
 
 [x-common-repo]: https://github.com/exercism/x-common

--- a/glossary.md
+++ b/glossary.md
@@ -9,10 +9,10 @@ context of Exercism.
 | **iteration**     | the code that someone writes to make a test suite pass                                                                   |
 | **language**      | the name of a programming language, for example _C++_ or _Haskell_                                                       |
 | **problem**       | abstract concept for a programming task on exercism.io                                                                   |
-| **slug**          | a short, unique identifier for a **problem**, **specification**, or **exercise** (e.g. `hamming`). Matches `/^[a-z-]+$/` |
+| **slug**          | a short, unique identifier for a **problem**, **specification**, or **exercise** (e.g. `hamming`). Matches `/^[a-z]+(-[a-z]+)*$/` |
 | **solution**      | a collection of **iterations** that a single person has done to solve an **exercise**                                    |
 | **specification** | a language-agnostic description of a **problem**. These live in [the x-common repository][x-common-repo]                 |
 | **track**         | a collection of **exercises** implemented in a given **language**                                                        |
-| **track id**      | a short, unique identifier for a track (e.g. `cpp` or `haskell`). Matches `/^[a-z-]+$/`                                  |
+| **track id**      | a short, unique identifier for a track (e.g. `cpp` or `haskell`). Matches `/^[a-z]+(-[a-z]+)*$/`                                  |
 
 [x-common-repo]: https://github.com/exercism/x-common


### PR DESCRIPTION
New regex disallows:

* `hello-world-` (trailing dash)
* `hello--world` (multiple consecutive dashes)
* `-hello-world` (leading dash)

Regex breakdown:

```
[a-z]+(-[a-z]+)*
^^^^^^             Initial word consisting of at least 1 lowercase character
      ^^^^^^^^^^   Optional noninitial words separated from the previous word by a single dash and consisting of at least 1 lowercase character
```