### PR TITLE
Glossary: add Summary, add Implementation, change Exercise

### DIFF
--- a/glossary.md
+++ b/glossary.md
@@ -15,7 +15,7 @@ The **solution** to an exercise is made up of one or more **iterations**
 | **implementation** | a **language** specific test suite and documentation used to implement a **specification**                                                          |
 | **iteration**      | the code that someone writes to make a test suite pass                                                                                              |
 | **language**       | the name of a programming language, for example _C++_ or _Haskell_                                                                                  |
-| **problem**        | an abstract concept for a programming task on exercism.io                                                                                           |
+| **problem**        | the abstract concept for a programming task on exercism.io                                                                                        |
 | **slug**           | a short, unique identifier for a **problem**, **specification**, or **exercise** (e.g. `hamming`). Consists of lowercase words separated by hyphens |
 | **solution**       | a collection of **iterations** that a single person has done to solve an **exercise**                                                               |
 | **specification**  | a language-agnostic description of a **problem**. These live in [the x-common repository][x-common-repo]                                            |

--- a/glossary.md
+++ b/glossary.md
@@ -15,7 +15,7 @@ The **solution** to an exercise is made up of one or more **iterations**
 | **implementation** | a **language** specific test suite and documentation used to implement a **specification**                                                          |
 | **iteration**      | the code that someone writes to make a test suite pass                                                                                              |
 | **language**       | the name of a programming language, for example _C++_ or _Haskell_                                                                                  |
-| **problem**        | the abstract concept for a programming task on exercism.io                                                                                        |
+| **problem**        | the abstract concept of a programming task on exercism.io                                                                                           |
 | **slug**           | a short, unique identifier for a **problem**, **specification**, or **exercise** (e.g. `hamming`). Consists of lowercase words separated by hyphens |
 | **solution**       | a collection of **iterations** that a single person has done to solve an **exercise**                                                               |
 | **specification**  | a language-agnostic description of a **problem**. These live in [the x-common repository][x-common-repo]                                            |

--- a/glossary.md
+++ b/glossary.md
@@ -3,9 +3,16 @@
 There are a number of terms that we use that have specific meaning within the
 context of Exercism.
 
+## Summary
+
+People come to Exercism for the exercises and each **exercise** consists of the **specification** of a problem to solve and a concrete **implementation** of that problem.
+
+The **solution** to an exercise is made up of one or more **iterations**
+
 | Term              | Explanation                                                                                                                                         |
 |-------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
-| **exercise**      | a language-specific implementation of a **specification**. Typically consists of a test suite and a README                                          |
+| **exercise**       | an instance of a problem, made up of a **specification** and its **implementation**                                      |
+| **implementation** | **language** specific test suite and documentation used to implement a **specification**                                 |
 | **iteration**     | the code that someone writes to make a test suite pass                                                                                              |
 | **language**      | the name of a programming language, for example _C++_ or _Haskell_                                                                                  |
 | **problem**       | abstract concept for a programming task on exercism.io                                                                                              |

--- a/glossary.md
+++ b/glossary.md
@@ -9,17 +9,17 @@ People come to Exercism for the exercises and each **exercise** consists of the 
 
 The **solution** to an exercise is made up of one or more **iterations**
 
-| Term              | Explanation                                                                                                                                         |
-|-------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
-| **exercise**       | an instance of a problem, made up of a **specification** and its **implementation**                                      |
-| **implementation** | **language** specific test suite and documentation used to implement a **specification**                                 |
-| **iteration**     | the code that someone writes to make a test suite pass                                                                                              |
-| **language**      | the name of a programming language, for example _C++_ or _Haskell_                                                                                  |
-| **problem**       | abstract concept for a programming task on exercism.io                                                                                              |
-| **slug**          | a short, unique identifier for a **problem**, **specification**, or **exercise** (e.g. `hamming`). Consists of lowercase words separated by hyphens |
-| **solution**      | a collection of **iterations** that a single person has done to solve an **exercise**                                                               |
-| **specification** | a language-agnostic description of a **problem**. These live in [the x-common repository][x-common-repo]                                            |
-| **track**         | a collection of **exercises** implemented in a given **language**                                                                                   |
-| **track id**      | a short, unique identifier for a track (e.g. `cpp` or `haskell`). Consists of lowercase words separated by hyphens                                  |
+| Term               | Explanation                                                                                                                                         |
+|--------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| **exercise**       | an instance of a problem, made up of a **specification** and its **implementation**                                                                 |
+| **implementation** | a **language** specific test suite and documentation used to implement a **specification**                                                          |
+| **iteration**      | the code that someone writes to make a test suite pass                                                                                              |
+| **language**       | the name of a programming language, for example _C++_ or _Haskell_                                                                                  |
+| **problem**        | an abstract concept for a programming task on exercism.io                                                                                           |
+| **slug**           | a short, unique identifier for a **problem**, **specification**, or **exercise** (e.g. `hamming`). Consists of lowercase words separated by hyphens |
+| **solution**       | a collection of **iterations** that a single person has done to solve an **exercise**                                                               |
+| **specification**  | a language-agnostic description of a **problem**. These live in [the x-common repository][x-common-repo]                                            |
+| **track**          | a collection of **exercises** implemented in a given **language**                                                                                   |
+| **track id**       | a short, unique identifier for a track (e.g. `cpp` or `haskell`). Consists of lowercase words separated by hyphens                                  |
 
 [x-common-repo]: https://github.com/exercism/x-common


### PR DESCRIPTION
Update glossary based on discussion in: https://github.com/exercism/discussions/issues/145

Which helped settle on definitions for: Specification, Implementation, Exercise and Problem

Added: Summary section, Definition of implementation
Changed: Exercise

I also added the summary here, I'm not sure if this is the best place for it, but figured it could be moved somewhere more appropriate once that place is identified.

Meta note: I really don't like how the table formatting makes the diffs noisy.


