### PR TITLE
Fix closing underscore.

### DIFF
--- a/maintaining-a-track/track-level-linting-with-configlet.md
+++ b/maintaining-a-track/track-level-linting-with-configlet.md
@@ -11,4 +11,4 @@ which will make a guess at what operating system and architecture you have and
 attempt to download the right one.
 
 Verify the config by calling `bin/configlet .` (notice the dot). This says
-_check the config of the language track that is stored right here).
+_check the config of the language track that is stored right here_.


### PR DESCRIPTION
The last line had mismatched delimiters.
The text was either meant to be in _italic_ or surrounded by (parentheses).
I've gone for _italic_