### PR TITLE
Add details to the 'invite maintainer' process doc

### DIFF
--- a/maintaining-a-track/inviting-new-maintainers.md
+++ b/maintaining-a-track/inviting-new-maintainers.md
@@ -9,3 +9,7 @@ General topics that we feel are good to touch on in the invitation:
 * **Thank you** for your past contributions. Be specific on points that we like, for positive reinforcement.
 * https://github.com/exercism/docs/tree/master/maintaining-a-track
 * **No pressure** regarding how much to commit to (you can commit to as much or as little as you like!), or even to say yes at all! Either way, you are still welcome to contribute as you already have been!
+
+If they agree to become maintainers, email [@kytrinyx](https://github.com/kytrinyx) and she'll add them to the correct team.
+
+We're talking about adding some sort of bot that will let maintainers invite new maintainers in their track, but we haven't gotten that far.


### PR DESCRIPTION
I got an email today from one of the track maintainers asking what the process is, and realized that we were missing a few details here.