### PR TITLE
Fix broken links in documentation.

### DIFF
--- a/about/architecture.md
+++ b/about/architecture.md
@@ -9,7 +9,7 @@ The main components that make up Exercism are:
 
 ### The Website
 
-The [exercism.io](http://exercism.io/) website is a vital part of the [product](https://github.com/exercism/exercism.io/blob/master/docs/overview-of-exercism.md#the-product). The community uses the site to:
+The [exercism.io](http://exercism.io/) website is a vital part of the [product](https://github.com/exercism/docs/blob/master/about/README.md#the-product). The community uses the site to:
 
 - get an overview of the available problems and languages
 - provide and receive feedback

--- a/contributing/git-basics.md
+++ b/contributing/git-basics.md
@@ -183,7 +183,7 @@ helpful:
 
 * [Git for Ages 4 and Up](https://www.youtube.com/watch?v=1ffBJ4sVUb4) - video of a presentation/demo
 * [Think Like a Git](http://think-like-a-git.net/)
-* [Explain Git with D3](http://www.wei-wang.com/ExplainGitWithD3) - interactive site
+* [Explain Git with D3](https://onlywei.github.io/explain-git-with-d3/) - interactive site
 * [Pro Git](http://git-scm.com/book/en/v2) - "The Book" for learning Git in detail
 * [Git Branching Tutorial](http://pcottle.github.io/learnGitBranching/) - interactive tutorial, very visual
 

--- a/maintaining-a-track/README.md
+++ b/maintaining-a-track/README.md
@@ -59,7 +59,7 @@ The exercises often start out as an experiment. As people do the exercises we le
 
 Over time we try to:
 
-- improve the problem descriptions in [exercism/problem-specifications](github.com/exercism/problem-specifications)
+- improve the problem descriptions in [exercism/problem-specifications](https://github.com/exercism/problem-specifications)
 - add missing edge cases in the test suites
 - reorder tests to allow a more incremental approach to solving the problem
 - improve the test suites to avoid pushing people towards specific solutions


### PR DESCRIPTION
This fixes a few broken links. One of which (the overview-of-exercism
link) seems like it should now point to the overview-architecture page,
which is what I've made it do.

Thanks for the great website! Love Exercism!