### PR TITLE
exercises: Document `title`

### DIFF
--- a/language-tracks/exercises/anatomy/readmes.md
+++ b/language-tracks/exercises/anatomy/readmes.md
@@ -44,7 +44,7 @@ There are a number of values available in the template:
 `.Spec` represents the problem specification, which is either a shared specification from [problem-specifications][], or a custom specification found in the exercise's `.meta` directory. The following values on `.Spec` can be referenced within the template:
 
 - `.Spec.Slug` - the exercise's slug
-- `.Spec.Name` - the wordified slug
+- `.Spec.Name` - a human-readable form of the exercise's name. If present in the specification, this is the `title`, otherwise it is the wordified slug
 - `.Spec.Description` - the contents of the optional `$TRACK_ROOT/exercises/$SLUG/.meta/description.md` file
 - `.Spec.Source` - a textual description of where the idea for the exercise came from (optional)
 - `.Spec.SourceURL` - a link to something about the source (optional)

--- a/language-tracks/exercises/anatomy/readmes.md
+++ b/language-tracks/exercises/anatomy/readmes.md
@@ -44,7 +44,7 @@ There are a number of values available in the template:
 `.Spec` represents the problem specification, which is either a shared specification from [problem-specifications][], or a custom specification found in the exercise's `.meta` directory. The following values on `.Spec` can be referenced within the template:
 
 - `.Spec.Slug` - the exercise's slug
-- `.Spec.Name` - a human-readable form of the exercise's name. If present in the specification, this is the `title`, otherwise it is the wordified slug
+- `.Spec.Name` - the wordified slug
 - `.Spec.Description` - the contents of the optional `$TRACK_ROOT/exercises/$SLUG/.meta/description.md` file
 - `.Spec.Source` - a textual description of where the idea for the exercise came from (optional)
 - `.Spec.SourceURL` - a link to something about the source (optional)

--- a/you-can-help/make-up-new-exercises.md
+++ b/you-can-help/make-up-new-exercises.md
@@ -25,6 +25,7 @@ The `metadata.yml` contains the blurb and source. It has the following structure
 ```
 ---
 blurb: "A one-sentence summary of the problem to be solved."
+title: "An *optional* field containing the name of this exercise if the default algorithm does not correctly convert the slug to the correct name. The default algorithm capitalises the first letter of each hyphen-separated word. If the default algorithm correctly converts the slug, this field can/should be omitted."
 source: "A textual description of where this was found, or what inspired it."
 source_url: "http://example.com/reference"
 ```


### PR DESCRIPTION
In generated READMEs, the rule for converting an exercise slug to a
human-readable form is to capitalise only the first letter of each
hyphen-separated word.

For some exercises this is not the best possible title. For example see
http://exercism.io/exercises/haskell/rna-transcription/readme and
observe that the title is "Rna Transcription", whereas "RNA
Transcription" seems more faithful to the rules (RNA, as an initialism,
should be in all caps).

For those exercises, we add an optional `title` field in metadata.yml to
allow overriding the default capitalisation or punctuation.

This documents this field and how it is used in README generation.

Discussion:
https://github.com/exercism/configlet/issues/76

Addition of `title` field:
https://github.com/exercism/problem-specifications/pull/901

Implementation in `configlet`:
https://github.com/exercism/configlet/pull/85