### PR TITLE
Remove superfluous text in triage-issues.md

### DIFF
--- a/you-can-help/triage-issues.md
+++ b/you-can-help/triage-issues.md
@@ -8,7 +8,7 @@ fixed.
 
 The goal of triaging issues is to make sure that each issue is actionable.
 
-A great issue also has enough context that it could be tackled by someone who has never contributed
+A great issue has enough context that it could be tackled by someone who has never contributed
 to Exercism before.
 
 When reading an issue you should be able to answer questions like...


### PR DESCRIPTION
I found the "also" additional a bit odd here, but maybe it's just me.