### PR TITLE
Update "implement an exercise from specification"

### DIFF
--- a/language-tracks/configuration/exercises.md
+++ b/language-tracks/configuration/exercises.md
@@ -72,3 +72,4 @@ Exercises can be deprecated, in which case they must have the following:
 All other fields in deprecated exercises can be deleted.
 
 [configlet]: /language-tracks/configuration/configlet.md
+[topics]: https://github.com/exercism/problem-specifications/blob/master/TOPICS.txt

--- a/language-tracks/configuration/exercises.md
+++ b/language-tracks/configuration/exercises.md
@@ -59,6 +59,7 @@ Use a scale from 1 to 10.
 
 We show the topics for an exercise on the website.
 This lets people optimize the learning experience to their own interests—skipping topics that they are not interested in, or that they already know a lot about, and doing deeper dives into topics that they're curious about.
+Take a look at the (non-exhaustive) [topics list][topics] for suggestions of topics to add.
 
 ## Deprecating exercises
 

--- a/you-can-help/implement-an-exercise-from-specification.md
+++ b/you-can-help/implement-an-exercise-from-specification.md
@@ -2,8 +2,8 @@
 
 [problem-specifications]: http://github.com/exercism/problem-specifications/tree/master/exercises
 [support-chat]: https://gitter.im/exercism/support
-[topics]: https://github.com/exercism/problem-specifications/blob/master/TOPICS.txt
 [configlet]: https://github.com/exercism/configlet#configlet
+[exercises]: /language-tracks/configuration/exercises.md
 
 Exercism has a lot of exercises in a lot of languages.
 

--- a/you-can-help/implement-an-exercise-from-specification.md
+++ b/you-can-help/implement-an-exercise-from-specification.md
@@ -101,16 +101,7 @@ that the exercise is coherent.
 
 Add a new entry in the `exercises` key in the `config.json` file in the root of the repository.
 
-Add the slug, estimate the difficulty level. Topics are optional, but can be really helpful.
-
-
-    {
-      "slug": <slug>,
-      "difficulty": <a number from 1 to 10>,
-      "topics": [ ]
-    }
-
-Take a look at the (non-exhaustive) [topics list][topics] and see if any of these make sense.
+See the [exercise configuration document][exercises] for a detailed description of what you need to add to this entry.
 
 We have a tool, [configlet][configlet] that will help make sure that everything is configured right.
 Download that and run it against the track repository.


### PR DESCRIPTION
When updating the Java track documentation we noticed that the "implement an exercise from specification" documentation was slightly out of date in its description of the exercises object.
This has been updated with a link to the exercises.md document which explains in detail what should be in the exercises object (in config.json).

Also, the exercises.md document didn't have a link to the topics list so that has been added.

This should hopefully fix #92.

This is my first time making any changes to this repository so please let me know if I should have done anything differently :)