### PR TITLE
implement-an-exercise-from-specification: Remove avoiding duplicate work section.

### DIFF
--- a/you-can-help/implement-an-exercise-from-specification.md
+++ b/you-can-help/implement-an-exercise-from-specification.md
@@ -45,24 +45,6 @@ For every exercise it will link to:
 - The canonical data (if it exists).
 - All the individual language implementations.
 
-## Avoiding Duplicate Work
-
-When you decide to implement an exercise, first check that there are no open pull requests
-for the same exercise.
-
-Then open a "work in progress" (WIP) pull request, so others will see that you're working on it.
-
-The way to open a WIP pull request even if you haven't done any work yet is:
-
-* Fork and clone the repository.
-* Check out a branch for the exercise.
-* Add an empty commit `git commit --allow-empty -m "Implement exercise <slug>"`
-  (replace <slug> with the actual name of the exercise).
-* Push the new branch to your repository, and open a pull request against that branch.
-
-Once you have added the actual exercise, then you can rebase your branch onto the upstream
-master, which will make the WIP commit go away.
-
 ## Implementing the Exercise
 
 You'll need to find the `slug` for the exercise. That's the URL-friendly identifier


### PR DESCRIPTION
The Avoiding Duplicate Work section encourages people to create empty WIP pull requests.

But:

* Most of these are never followed through on and become more of a
  problem for track maintainers than than the far less likely
  implementation collisions.

* Tracks should be able to specify their own procedures for creating
  pull requests.

So:

Remove this section from the common documentation, if tracks think that
it is important to have WIP commits they can add them to their local
track documentation.
