### PR TITLE
exercises.md: add instruction for uuid length

### DIFF
--- a/language-tracks/configuration/exercises.md
+++ b/language-tracks/configuration/exercises.md
@@ -20,6 +20,7 @@ All other values can be updated.
 
 This must be unique to this particular exercise implementation across all of Exercism's tracks, and must never change.
 [Configlet][configlet] has a `uuid` subcommand (`configlet uuid`), but you can use any UUID generator tool to create it.
+The UUID should be of the form xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx.
 
 ### Slug
 

--- a/language-tracks/configuration/exercises.md
+++ b/language-tracks/configuration/exercises.md
@@ -20,6 +20,7 @@ All other values can be updated.
 
 This must be unique to this particular exercise implementation across all of Exercism's tracks, and must never change.
 [Configlet][configlet] has a `uuid` subcommand (`configlet uuid`), but you can use any UUID generator tool to create it.
+If you do use configlet make sure the configlet version agrees with the [latest configlet version](https://github.com/exercism/configlet/releases/latest).
 The UUID should be of the form xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx.
 
 ### Slug


### PR DESCRIPTION
On the Java track we've had quite a few people submit new exercises with uuids that are too long. I thought it might be nice to document the structure of the uuid for people who don't use configlet or use an old version of configlet :)