### PR TITLE
Update information on deprecating exercises

### DIFF
--- a/language-tracks/configuration/exercises.md
+++ b/language-tracks/configuration/exercises.md
@@ -69,13 +69,15 @@ Take a look at the (non-exhaustive) [topics list][topics] for suggestions of top
 
 ## Deprecating exercises
 
-Exercises can be deprecated, in which case they must have the following:
+Deleting an exercise is a destructive action it would delete all users' solutions to that exercise. Instead, we allow exercises to be deprecated, users who have completed the exercise can access their existing solutions, those who have not will not see or be able to start the exercise.
+
+Deprecated exercises must have the following set in `config.json`:
 
 - **uuid**
 - **slug**
 - **deprecated** (boolean, true)
 
-All other fields in deprecated exercises can be deleted.
+All other fields in deperecated exercises should remain as is.
 
 [configlet]: /language-tracks/configuration/configlet.md
 [topics]: https://github.com/exercism/problem-specifications/blob/master/TOPICS.txt


### PR DESCRIPTION
As per this discussion on Slack: https://exercism-team.slack.com/archives/GC3K95MRR/p1557390406008000

**coriolinus   [May 9th at 4:26 AM]**
Does anyone here know exactly what the distinction between `deprecated` and `foregone` exercises is? There's some discussion in https://github.com/exercism/rust/pull/830 which revolves around the semantics of those terms, and it would be good to have an understanding of the overall team intent. (edited)
_11 replies_

**NobbZ   [23 days ago]**
`deprecated` exercises have been implemented in this track previously but shall not be served to students anymore. Their implementation is usually kept in the repository for historical reasons. Also students know those exist could download those exercises through the CLI. `foregone` exercises are not implemented in the track and probably will never because they do not make sense in the context of the track. There is no implementation for those available.

**coriolinus   [23 days ago]**
If an exercise is deprecated, and the track maintainers remove the `exercises/foo` implementation, and a student attempts to get the exercise with the CLI, what happens?

**NobbZ   [23 days ago]**
I have no clue. But `configlet lint` should fail if an exercise is deprecated and not available IIRC.

**coriolinus   [23 days ago]**
it does! And that's been the cause of some issues for Rust recently, because it wasn't otherwise documented that deprecated exercises must have their implementations preserved. It looked like configlet was improperly failing to ignore implementation checks for deprecated exercises, instead of properly ensuring they stuck around for posterity.

Do you suppose that it would be acceptable to redefine things such that students can no longer download deprecated exercises from the CLI?

**NobbZ   [23 days ago]**
No

**NobbZ   [23 days ago]**
Sometimes I like to (re)do them (edited)

**ihid   [23 days ago]**
Deleting an exercise would delete everyone's solutions (foreign key constraints etc). So deprecated exists to be non destructive but also to imply that maintainers will no longer be updating/supporting that exercise.

**coriolinus   [23 days ago]**
Ok, this clarifies things. Thanks all!

It would be very nice if this were part of the public maintainer documentation, but that's probably not a particularly high priority.

**ihid   [23 days ago]**
Where would this go?

**coriolinus   [23 days ago]**
not sure. Probably https://github.com/exercism/docs/blob/master/language-tracks/configuration/track.md or https://github.com/exercism/docs/blob/master/language-tracks/configuration/configlet.md
language-tracks/configuration/configlet.md
exercism/docsAdded by GitHub
