### PR TITLE
Add copy about ordering exercises to exercises.md -- v2

### DIFF
--- a/language-tracks/configuration/exercises.md
+++ b/language-tracks/configuration/exercises.md
@@ -67,6 +67,10 @@ We show the topics for an exercise on the website.
 This lets people optimize the learning experience to their own interests—skipping topics that they are not interested in, or that they already know a lot about, and doing deeper dives into topics that they're curious about.
 Take a look at the (non-exhaustive) [topics list][topics] for suggestions of topics to add.
 
+## Order of exercises
+
+Exercises that are not part of the core track (`"core": false`) should be added to `config.json` on a line after the last core exercise (i.e. all core exercises are located at the top of the file, above all side exercises).
+
 ## Deprecating exercises
 
 Deleting an exercise is a destructive action it would delete all users' solutions to that exercise. Instead, we allow exercises to be deprecated, users who have completed the exercise can access their existing solutions, those who have not will not see or be able to start the exercise.

--- a/language-tracks/configuration/exercises.md
+++ b/language-tracks/configuration/exercises.md
@@ -69,7 +69,9 @@ Take a look at the (non-exhaustive) [topics list][topics] for suggestions of top
 
 ## Order of exercises
 
-Exercises that are not part of the core track (`"core": false`) should be added to `config.json` on a line after the last core exercise (i.e. all core exercises are located at the top of the file, above all side exercises).
+**Core Exercises**: Core exercises (`"core": true`) are unlocked in the order that they appear in `config.json`. For example, if Exercise A is listed before Exercise B and both are core exercises, then Exercise B would be unlocked upon completion of Exercise A.
+
+**Side Exercises**: Exercises that are not part of the core track (`"core": false`) may appear in any order so long as they appear on a line after the last core exercise in `config.json` (i.e. all core exercises are located at the top of the file, above all side exercises).
 
 ## Deprecating exercises
 


### PR DESCRIPTION
Reset the branch a bit too far back when consolidating commits on the last PR. Thought it would be cleaner to create a new PR with changes suggested in the comments in #129.

Quoting #129:

> Add copy about ordering exercises in exercises.md

Original issue: #116