### PR TITLE
docs: Correct links for unimplemented exercises

### DIFF
--- a/language-tracks/exercises/anatomy/test-suites.md
+++ b/language-tracks/exercises/anatomy/test-suites.md
@@ -38,4 +38,4 @@ Feel free to implement a test generator for your track if you feel it would aid 
 
 The specifications in `canonical-data.json` are the strongly recommended defaults, but if you have a good reason (language idioms, etc) then don't hesitate to deviate from them.
 
-If there is no `canonical-data.json` file for the exercise then we recommend using http://exercism.io/languages/vimscript/todo (replace vimscript with your track) to find other implementing tracks.
+If there is no `canonical-data.json` file for the exercise then we recommend using https://tracks.exercism.io/ to find other tracks that have implemented the exercise.

--- a/you-can-help/implement-an-exercise-from-specification.md
+++ b/you-can-help/implement-an-exercise-from-specification.md
@@ -32,9 +32,9 @@ to create a test suite in your target language.
 
 ## Finding an Exercise to Port
 
-Navigate to the language track on Exercism via the [http://exercism.io/languages](http://exercism.io/languages) page.
+Navigate to the language track on Exercism via the [https://tracks.exercism.io](https://tracks.exercism.io) page.
 
-The last item in the sidebar will be about contributing. Go to that section.
+Select the language of interest. You shall see a table that has multiple tabs. Click the tab labelled **Unimplemented**.
 
 This is a full list of every exercise that exists, but has not yet been implemented
 in that language track.


### PR DESCRIPTION
* Closes https://github.com/exercism/exercism/issues/4118

Correct the link to unimplemented exercises and another link to fit the stated goal of discovering other exercises that implemented a given exercise.