### PR TITLE
Update exercise README default template

### DIFF
--- a/language-tracks/exercises/anatomy/readmes.md
+++ b/language-tracks/exercises/anatomy/readmes.md
@@ -74,12 +74,12 @@ The default contents of `$TRACK_ROOT/config/exercise-readme.go.tmpl` is below.
 
 {{ .Spec.Description -}}
 {{- with .Hints }}
-{{ . }}
+{{ . -}}
 {{ end }}
 {{- with .TrackInsert }}
-{{ . }}
+{{ . -}}
 {{ end }}
-{{- with .Spec.Credits -}}
+{{- with .Spec.Credits }}
 ## Source
 
 {{ . }}


### PR DESCRIPTION
The improvement to the template ensure that the generated README have consistent single newline in the event of missing `.Hints`, `.TrackInsert`, and/or `.Spec.Credits`.